### PR TITLE
Support running CI script on local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Templates are pre-built automated business processes that can be imported in Okt
 *   Push the remote branch with force `-f` option e.g `git push -f origin <branch-name>`
 
 *   Test CI script on local setup
+    ### Install dependencies (one time only)
     *   npm install ajv
     *   npm install shelljs
 
-    ### Run below script from root of git repo. All files should have commit to have diff with master
+    ### Run below script from root of git repo to test remote branch. All files should have commit to diff with master
 
     *   git checkout `remotebranch`
     *   node scripts/schema_validate.js `remotebranch`

--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ Templates are pre-built automated business processes that can be imported in Okt
 *   Change the last commit message with command `git commit --amend`. Add [skip ci] or [ci skip] to commit message
 
 *   Push the remote branch with force `-f` option e.g `git push -f origin <branch-name>`
+
+*   Test CI script on local setup
+    *   npm install ajv
+    *   npm install shelljs
+
+    ### Run below script from root of git repo. All files should have commit to have diff with master
+
+    *   git checkout `remotebranch`
+    *   node scripts/schema_validate.js `remotebranch`
+    *   sh scripts/travis_release.sh `remotebranch`

--- a/scripts/schema_validate.js
+++ b/scripts/schema_validate.js
@@ -2,10 +2,10 @@ const Ajv = require('ajv');
 const shell = require('shelljs')
 
 // Fetch the JSON content for schema
+let baseDir;
+let branchName;
+let prWorkFlowJSONFiles;
 const workflowSchema = require('./workflow-schema.json');
-const baseDir = shell.exec('echo ${TRAVIS_BUILD_DIR}').replace(/\n/g, '');
-const branchName = shell.exec('echo ${TRAVIS_BRANCH}');
-const prWorkFlowJSONFiles = shell.exec('git diff --name-only ${TRAVIS_BRANCH}..HEAD -- \'workflows/*/*.json\'').replace(/\n/g, ' ');
 
 // Process PR files with only filter workflows/*/*.json
 function processPRFiles() {
@@ -27,4 +27,20 @@ function processPRFiles() {
    });
 }
 
+function processArgsAndInitializeVals() {
+  if (process.argv.length > 2) {
+    console.log('Running locally');
+    branchName = process.argv.slice(2);
+    console.log(`Testing for git branch  ${branchName}`);
+    baseDir = process.cwd();
+    prWorkFlowJSONFiles = shell.exec(`git diff --name-only ${branchName}..master -- \'workflows/*/*.json\'`).replace(/\n/g, ' ');
+  } else {
+    console.log('Running in Travis-CI config');
+    baseDir = shell.exec(`echo ${TRAVIS_BUILD_DIR}`).replace(/\n/g, '');
+    branchName = shell.exec(`echo ${TRAVIS_BRANCH}`);
+    prWorkFlowJSONFiles = shell.exec(`git diff --name-only ${TRAVIS_BRANCH}..HEAD -- \'workflows/*/*.json\'`).replace(/\n/g, ' ');
+  }
+}
+
+processArgsAndInitializeVals();
 processPRFiles();

--- a/scripts/travis_release.sh
+++ b/scripts/travis_release.sh
@@ -8,13 +8,22 @@ const_supported_connectors="connectors.json"
 
 # save workflow directories in glorbal variable
 directories=()
-echo "branch name ${TRAVIS_BRANCH} and build is $TRAVIS_BUILD_DIR"
-
-# get only pull request files from branch. TODO: any other better way
-pr_files="$(git diff --name-only ${TRAVIS_BRANCH}...HEAD --)"
-base_dir=$TRAVIS_BUILD_DIR
+if [ -z "$1" ]
+    then
+        # running travis-ci config
+        branch_name=$TRAVIS_BRANCH
+        base_dir=$TRAVIS_BUILD_DIR
+        pr_files="$(git diff --name-only ${branch_name}...HEAD --)"
+    else
+        # running local config
+        branch_name=$1
+        base_dir=$PWD
+        pr_files="$(git diff --name-only ${branch_name}..master --)"
+fi
+# get only pull request files from branch.
 echo "base dir is ${base_dir}"
 echo "PR files are ${pr_files} \n"
+echo "branch name ${branch_name} and build is ${base_dir}"
 
 # utility to lookup if element exists in an array 
 array_contains () { 


### PR DESCRIPTION
Fix for OKTA-341561: support running CI script on local env

on local env install below dependencies
npm install ajv
npm install shelljs

Run below script from root of git repo. All files should have commit to have diff with master
1) checkout the remote branch to test. 
	git checkout `remotebranch`
2) validate files with schema
	node scripts/schema_validate.js `remotebranch`
3) validate files for more rules
	sh scripts/travis_release.sh `remotebranch`