### PR TITLE
[OKTA-716051] fix: fix template Title for automate_lifecycle_management_with_darwinbox

### DIFF
--- a/workflows/automate_lifecycle_management_with_darwinbox/readme.md
+++ b/workflows/automate_lifecycle_management_with_darwinbox/readme.md
@@ -1,3 +1,3 @@
-# Automate lifecycle management with DarwinBox
+# Automate lifecycle management with Darwinbox
 
 This template is built and provided by Darwinbox. For instructions on using this template with Darwinbox, see [Darwinbox](https://marketplace.darwinbox.com/en-US/apps/435602/okta/resources).

--- a/workflows/automate_lifecycle_management_with_darwinbox/workflow.json
+++ b/workflows/automate_lifecycle_management_with_darwinbox/workflow.json
@@ -1,6 +1,6 @@
 {
   "name": "automate_lifecycle_management_with_darwinbox",
-  "title": "Automate lifecycle management with DarwinBox",
+  "title": "Automate lifecycle management with Darwinbox",
   "description": "These flows outline how Okta Workflows can be used to automate user creation, updates, and deactivation processes, including the automatic update of email IDs in Darwinbox.",
   "connectors": [
     "okta",


### PR DESCRIPTION
Template: automate_lifecycle_management_with_darwinbox
Template name: Automate lifecycle management with Darwinbox

Ticket: https://oktainc.atlassian.net/browse/OKTA-716051

Main change: the connector name is Darwinbox not DarwinBox.

@JirongYang-okta Please approve~